### PR TITLE
Fix slugbuilder when builds doesn't have dockerfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+sudo: required
+env:
+  matrix:
+  - DOCKER_REGISTRY=quay.io DEIS_REGISTRY=${DOCKER_REGISTRY}/ IMAGE_PREFIX=tfgco
+  global:
+  - secure: ISPH23zfWZXsFpOXTwk0hwG5DLuIWCb/7ZS9ozFWytNdlM3doPwXgqvzCSkMiFyn4nKngnNGdttoXCc9JdsaytVylZ9vnT2wYjL6niqbWX6vRYkLGFj6FRyYuO38x4TMPnIKsOus4CtiuESBtYFIo4DC1r8+nueam2zXQ0Kf9vrqeswuPQJ89jErirISU9yAlZxANd4VEa4gQZq85TWnU8D75j+EtvsNkIOl3BIVSuTIu6ZLPT0uyrCWBTxoZU2UF6F+dNlMBfwHXl5F5bY+HcxZMtnLY4d9v0LYP2LaI464TnC6e71Y6+66Tp9wqUq0xloxxaOe9JQShvAsLYRcSD1gwNqA7sVmU5+g8miNmCYIAOH5qKeAEGiHzwFc5k/VfIsIDDWMHLx8N1iQ1WNCpBShJPn3aI1L0cKTdVZJrZqO8HeNSN5Xi3BcEOUoBxE/R2Uo76YDa2b0yy8C1NSA1d0pCPhSw11UStPiuqjW2jXfOwQG0uksP334o8Za3n6iIseYThmsMRg9H0UC/7X9OaTqFdXHoQAAf3CK+2QrpI9bir0scsZivQ9WyN6hx9j43iydkAbE3jrsrv/ytilRwOsS32ix/bW/WgZOCuehCzwc6LNwRciKEJXifhMYnMsWhQbsWTNAPM04hd9VmfCtnmAMDMgFEcRGuahl4m2Z6nY=
+services:
+- docker
+script:
+- make bootstrap
+- make docker-build test-style test-unit
+after_success:
+- docker login -u $DOCKER_USER -p $DOCKER_PASSWORD $DOCKER_REGISTRY
+- make docker-push

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ export GO15VENDOREXPERIMENT=1
 # Note that Minio currently uses CGO.
 
 LDFLAGS := "-s -X main.version=${VERSION}"
-IMAGE_PREFIX ?= deis
+IMAGE_PREFIX ?= tfgco
 BINDIR := ./rootfs/bin
 
 include versioning.mk

--- a/rootfs/builder/build.sh
+++ b/rootfs/builder/build.sh
@@ -102,7 +102,7 @@ export STACK=cedar-14
 ## copy the environment dir excluding the ephemeral ..data/ dir and other symlinks created by Kubernetes.
 
 if [ "$(ls -A $secret_dir)" ]; then
-   cp $secret_dir/* $env_root/
+   cp -r $secret_dir/. $env_root/
 fi
 
 ## SSH key configuration


### PR DESCRIPTION
It seems when a build doesn't have a Dockerfile, build fails.
This is the undesired output:
`cp: cannot stat '/tmp/env/*': No such file or directory`

This PR changes how slugbuilder copy data from `[pod_name]-build-env` secret when this secret is empty.